### PR TITLE
Fixed path to Xvfb

### DIFF
--- a/docker/etc/supervisord.d/processes.ini
+++ b/docker/etc/supervisord.d/processes.ini
@@ -42,7 +42,7 @@ stderr_logfile_maxbytes=0
 
 [program:x11server]
 user=archive
-command=usr/bin/Xvfb :99
+command=/usr/bin/Xvfb :99
 redirect_stderr=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
Added / to command name in x11 frame buffer command. The x11 frame buffer is needed by idl for debugging.