### PR TITLE
Bugfix/cals and trace12

### DIFF
--- a/nrespipe/tasks.py
+++ b/nrespipe/tasks.py
@@ -177,8 +177,9 @@ def refine_trace_from_night(site, camera, nres_instrument, raw_data_root, night=
         flat1 = flats_1[(len(flats_1) + 1) // 2]
         flat2 = ''
     else:
-        flat1 = flats_2[(len(flats_2) + 1) // 2]
-        flat2 = ''
+        # Short circuit if there are only flats from fiber 1,2 and not 0,1
+        # This is a requirement of the idl pipeline.
+        return
 
     # run refine_trace on the main task queue
     # Note that flat1 should have fibers 0,1 illuminated while flat2 should have 1,2

--- a/nrespipe/utils.py
+++ b/nrespipe/utils.py
@@ -541,10 +541,10 @@ def get_missing_files(raw_directory, specproc_directory):
 
 
 def get_calibration_files_taken(raw_directory):
-    bias_files = glob(os.path.join(raw_directory, 'b00.fits.fz'))
-    dark_files = glob(os.path.join(raw_directory, 'd00.fits.fz'))
-    flat_files = glob(os.path.join(raw_directory, 'w00.fits.fz'))
-    arc_files = glob(os.path.join(raw_directory, 'a00.fits.fz'))
+    bias_files = glob(os.path.join(raw_directory, '*b00.fits.fz'))
+    dark_files = glob(os.path.join(raw_directory, '*d00.fits.fz'))
+    flat_files = glob(os.path.join(raw_directory, '*w00.fits.fz'))
+    arc_files = glob(os.path.join(raw_directory, '*a00.fits.fz'))
     return bias_files, dark_files, flat_files, arc_files
 
 


### PR DESCRIPTION
Fixed bug in reporting calibration files that were taken last night.


If flats with fibers 1,2 but no flat with fibers 0,1 are taken, we no longer make a new trace file.