### PR TITLE
set tharlist to arc_ThAr_Redman.txt, to give more lines fit

### DIFF
--- a/muncha.pro
+++ b/muncha.pro
@@ -119,7 +119,8 @@ case 1 of
   autoguider
   expmeter
   if not keyword_set(tharlist) then begin
-    tharlist = 'mtchThAr.txt'
+;    tharlist = 'mtchThAr.txt'
+     tharlist = 'arc_ThAr_Redman.txt'
   endif
   thar_wavelen,dbg=dbg,trp=trp,tharlist=tharlist,cubfrz=cubfrz,oskip=oskip
   if(not keyword_set(nostar)) then begin


### PR DESCRIPTION
One-line change to muncha.pro, chooses different (longer) list of lab ThAr lines to compare with observations.  Tested on 1 each tlv and lsc data.  Seems to improve output in both cases, at the expense of longer run time.