### PR TITLE
Update ingester version to use new metrics tag.

### DIFF
--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -82,7 +82,7 @@ sphinxcontrib-htmlhelp==1.0.2
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.2
 sphinxcontrib-serializinghtml==1.1.3
-SQLAlchemy==1.1.4
+SQLAlchemy>=1.3.0
 tornado==6.0.2
 traitlets==4.3.2
 urllib3==1.24.2

--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -89,4 +89,4 @@ urllib3==1.24.2
 vine==1.3.0
 wcwidth==0.1.7
 webencodings==0.5.1
-lco_ingester==2.1.5
+lco_ingester==2.1.11


### PR DESCRIPTION
We will need to add `INGESTER_PROCESS_NAME=nres_pipeline` to the Rancher deployment.